### PR TITLE
Update ClangTidy and ClangFormat configurations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,185 +1,84 @@
----
 Language: Cpp
-AccessModifierOffset: -2
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: Left
-AlignConsecutiveAssignments: Consecutive
-AlignConsecutiveBitFields: Consecutive
-AlignConsecutiveDeclarations: Consecutive
-AlignConsecutiveMacros: Consecutive
-AlignEscapedNewlines: Left
-AlignOperands: Align
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignOperands: true
 AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortEnumsOnASingleLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AllowShortLambdasOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: Never
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterDefinitionReturnType: All
 AlwaysBreakAfterReturnType: AllDefinitions
-AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
-AttributeMacros:
-  - __capability
-BinPackArguments: true
-BinPackParameters: true
-BreakBeforeBraces: Custom
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel: true
   AfterClass: true
-  AfterControlStatement: Always
+  AfterControlStatement: true
   AfterEnum: true
   AfterFunction: true
   AfterNamespace: true
-  AfterObjCDeclaration: false
   AfterStruct: true
   AfterUnion: true
   AfterExternBlock: true
   BeforeCatch: true
   BeforeElse: true
   BeforeLambdaBody: true
-  BeforeWhile: false
+  BeforeWhile: true
   IndentBraces: false
-  SplitEmptyFunction: false
-  SplitEmptyRecord: false
-  SplitEmptyNamespace: false
-BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: true
-BreakBeforeInheritanceComma: true
-BreakInheritanceList: AfterComma
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBraces: Custom
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: true
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit: 120
-CommentPragmas: '^ IWYU pragma:'
-QualifierAlignment: Left
+BreakConstructorInitializers: BeforeComma
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 140
 CompactNamespaces: false
-ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
-Cpp11BracedListStyle: false
-DeriveLineEnding: true
-DerivePointerAlignment: false
-DisableFormat: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ContinuationIndentWidth: 8
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
-ExperimentalAutoDetectBinPacking: false
-PackConstructorInitializers: Never
-FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IfMacros:
-  - KJ_IF_MAYBE
 IncludeBlocks: Preserve
 IncludeCategories:
-  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority: 2
-    SortPriority: 0
-    CaseSensitive: false
-  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
-    Priority: 3
-    SortPriority: 0
-    CaseSensitive: false
-  - Regex: '.*'
+  - Regex: '^<.*'
     Priority: 1
-    SortPriority: 0
-    CaseSensitive: false
-IncludeIsMainRegex: '(Test)?$'
-IncludeIsMainSourceRegex: ''
-IndentAccessModifiers: false
+  - Regex: '^".*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseBlocks: false
 IndentCaseLabels: true
-IndentCaseBlocks: true
 IndentGotoLabels: true
-IndentPPDirectives: AfterHash
-IndentExternBlock: AfterExternBlock
+IndentPPDirectives: BeforeHash
 IndentWidth: 4
 IndentWrappedFunctionNames: false
-InsertTrailingCommas: None
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-LambdaBodyIndentation: Signature
+InsertNewlineAtEOF: true
 MacroBlockBegin: ''
 MacroBlockEnd: ''
-MaxEmptyLinesToKeep: 1
+MaxEmptyLinesToKeep: 2
 NamespaceIndentation: All
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 2
-ObjCBreakBeforeNestedBlockParam: true
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakOpenParenthesis: 0
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
-PenaltyIndentedWhitespace: 0
 PointerAlignment: Right
-PPIndentWidth: -1
-ReferenceAlignment: Pointer
-ReflowComments: true
-RemoveBracesLLVM: false
-SeparateDefinitionBlocks: Always
-ShortNamespaceLines: 1
-SortIncludes: CaseSensitive
-SortJavaStaticImport: Before
-SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: false
-SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-SpaceBeforeParensOptions:
-  AfterControlStatements: true
-  AfterForeachMacros: true
-  AfterFunctionDefinitionName: false
-  AfterFunctionDeclarationName: false
-  AfterIfMacros: true
-  AfterOverloadedOperator: false
-  BeforeNonEmptyParentheses: false
-SpaceAroundPointerQualifiers: Default
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
+SpaceBeforeSquareBrackets: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles: Never
+SpacesInAngles: false
 SpacesInConditionalStatement: false
-SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
-SpacesInLineCommentPrefix:
-  Minimum: 1
-  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: Both
-Standard: c++17
-StatementAttributeLikeMacros:
-  - Q_EMIT
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
 TabWidth: 4
-UseCRLF: false
 UseTab: Never
-WhitespaceSensitiveMacros:
-  - STRINGIZE
-  - PP_STRINGIZE
-  - BOOST_PP_STRINGIZE
-  - NS_SWIFT_NAME
-  - CF_SWIFT_NAME

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,27 +1,50 @@
 ---
-Checks:          '-*,bugprone-argument-comment,bugprone-assert-side-effect,bugprone-assignment-in-if-condition,bugprone-bad-signal-to-kill-thread,bugprone-bool-pointer-implicit-conversion,bugprone-copy-constructor-init,bugprone-dangling-handle,bugprone-dynamic-static-initializers,bugprone-empty-catch,bugprone-exception-escape,bugprone-fold-init-type,bugprone-forward-declaration-namespace,bugprone-forwarding-reference-overload,bugprone-inaccurate-erase,bugprone-incorrect-roundings,bugprone-infinite-loop,bugprone-integer-division,bugprone-lambda-function-name,bugprone-macro-*,bugprone-misplaced-*,bugprone-move-forwarding-reference,bugprone-multiple-*,bugprone-narrowing-conversions,bugprone-no-escape,bugprone-non-zero-enum-to-bool-conversion,bugprone-not-null-terminated-result,bugprone-parent-virtual-call,bugprone-posix-return,bugprone-redundant-branch-condition,bugprone-reserved-identifier,bugprone-shared-ptr-array-mismatch,bugprone-signal-handler,bugprone-signed-char-misuse,bugprone-sizeof-*,bugprone-spuriously-wake-up-functions,bugprone-standalone-empty,bugprone-string-*,bugprone-stringview-nullptr,bugprone-suspicious-*,bugprone-swapped-arguments,bugprone-switch-missing-default-case,bugprone-terminating-continue,bugprone-throw-keyword-missing,bugprone-too-small-loop-variable,bugprone-unchecked-optional-access,bugprone-undefined-memory-manipulation,bugprone-undelegated-constructor,bugprone-unhandled-*,bugprone-unique-ptr-array-mismatch,bugprone-unused-*,bugprone-use-after-move,bugprone-virtual-near-miss,cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-avoid-capturing-lambda-coroutines,cppcoreguidelines-avoid-const-or-ref-data-members,cppcoreguidelines-avoid-goto,cppcoreguidelines-avoid-reference-coroutine-parameters,cppcoreguidelines-c-copy-assignment-signature,cppcoreguidelines-explicit-virtual-functions,cppcoreguidelines-init-variables,cppcoreguidelines-interfaces-global-init,cppcoreguidelines-macro-usage,cppcoreguidelines-misleading-capture-default-by-value,cppcoreguidelines-missing-std-forward,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-no-malloc,cppcoreguidelines-noexcept-*,cppcoreguidelines-prefer-member-initializer,cppcoreguidelines-pro-type-const-cast,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-pro-type-member-init,cppcoreguidelines-pro-type-static-cast-downcast,cppcoreguidelines-pro-type-union-access,cppcoreguidelines-pro-type-vararg,cppcoreguidelines-rvalue-reference-param-not-moved,cppcoreguidelines-slicing,cppcoreguidelines-special-member-functions,cppcoreguidelines-use-default-member-init,cppcoreguidelines-virtual-class-destructor,hicpp-avoid-*,hicpp-braces-around-statements,hicpp-deprecated-headers,hicpp-exception-baseclass,hicpp-explicit-conversions,hicpp-function-size,hicpp-invalid-access-moved,hicpp-member-init,hicpp-move-const-arg,hicpp-multiway-paths-covered,hicpp-new-delete-operators,hicpp-no-assembler,hicpp-no-malloc,hicpp-noexcept-move,hicpp-signed-bitwise,hicpp-special-member-functions,hicpp-static-assert,hicpp-undelegated-constructor,hicpp-uppercase-literal-suffix,hicpp-use-*,hicpp-vararg,misc-confusable-identifiers,misc-const-correctness,misc-definitions-in-headers,misc-header-include-cycle,misc-include-cleaner,misc-misleading-*,misc-new-delete-overloads,misc-no-recursion,misc-non-copyable-objects,misc-static-assert,misc-throw-by-value-catch-by-reference,misc-unconventional-assign-operator,misc-uniqueptr-reset-release,misc-unused-*,misc-use-anonymous-namespace,modernize-avoid-*,modernize-concat-nested-namespaces,modernize-deprecated-*,modernize-loop-convert,modernize-macro-to-enum,modernize-make-*,modernize-raw-string-literal,modernize-redundant-void-arg,modernize-replace-*,modernize-return-braced-init-list,modernize-shrink-to-fit,modernize-type-traits,modernize-unary-static-assert,modernize-use-auto,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-emplace,modernize-use-equals-*,modernize-use-nodiscard,modernize-use-noexcept,modernize-use-nullptr,modernize-use-override,modernize-use-transparent-functors,modernize-use-uncaught-exceptions,modernize-use-using,readability-avoid-*,readability-braces-around-statements,readability-const-return-type,readability-container-*,readability-delete-null-pointer,readability-duplicate-include,readability-else-after-return,readability-function-size,readability-identifier-naming,readability-implicit-bool-conversion,readability-inconsistent-declaration-parameter-name,readability-isolate-declaration,readability-make-member-function-const,readability-misleading-indentation,readability-misplaced-array-index,readability-non-const-parameter,readability-qualified-auto,readability-redundant-control-flow,readability-redundant-declaration,readability-redundant-function-ptr-dereference,readability-redundant-member-init,readability-redundant-preprocessor,readability-redundant-smartptr-get,readability-redundant-string-*,readability-simplify-*,readability-static-definition-in-anonymous-namespace,readability-string-compare,readability-suspicious-call-argument,readability-uniqueptr-delete-release,readability-uppercase-literal-suffix,readability-use-anyofallof'
-WarningsAsErrors: ''
-HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
-FormatStyle:     none
-CheckOptions:
-  llvm-else-after-return.WarnOnConditionVariables: 'false'
-  modernize-loop-convert.MinConfidence: reasonable
-  modernize-replace-auto-ptr.IncludeStyle: llvm
-  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
-  google-readability-namespace-comments.ShortNamespaceLines: '10'
-  cert-err33-c.CheckedFunctions: '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
-  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
-  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
-  google-readability-braces-around-statements.ShortStatementLines: '1'
-  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
-  google-readability-namespace-comments.SpacesBeforeComments: '2'
-  modernize-loop-convert.MaxCopySize: '16'
-  modernize-pass-by-value.IncludeStyle: llvm
-  modernize-use-nullptr.NullMacros: 'NULL'
-  llvm-qualified-auto.AddConstToQualified: 'false'
-  modernize-loop-convert.NamingStyle: CamelCase
-  llvm-else-after-return.WarnOnUnfixable: 'false'
-  google-readability-function-size.StatementThreshold: '800'
-...
-
+Checks: '-*
+cppcoreguidelines-*
+mpi-*
+bugprone-*
+-bugprone-easily-swappable-parameters
+-bugprone-non-zero-enum-to-bool-conversion
+cert-err52-cpp
+cert-err60-cpp
+cert-err34-c
+cert-str34-c
+cert-msc50-cpp
+cert-msc51-cpp
+cert-dcl58-cpp
+cert-flp30-c
+google-readability-casting
+google-default-arguments
+google-global-names-in-headers
+google-readability-todo
+google-runtime-int
+google-runtime-operator
+google-explicit-constructor
+google-build-using-namespace
+hicpp-multiway-paths-covered
+hicpp-exception-baseclass
+llvm-else-after-return
+misc-*
+-misc-definitions-in-headers
+-misc-coroutine-hostile-raii
+-misc-misleading-bidirectional
+-misc-non-private-member-variables-in-classes
+modernize-*
+-modernize-use-trailing-return-type
+openmp-use-default-none
+performance-*
+-performance-noexcept-swap
+-performance-no-int-to-ptr
+portability-simd-intrinsics
+readability-*
+-readability-function-size
+-readability-identifier-length
+-readability-suspicious-call-argument
+-readability-avoid-nested-conditional-operator
+-readability-isolate-declaration
+-readability-redundant-access-specifiers
+-readability-avoid-return-with-void-value
+-readability-avoid-unconditional-preprocessor-if
+-readability-function-cognitive-complexity
+-readability-identifier-naming
+-readability-reference-to-constructed-temporary'

--- a/examples/01_basic/main.cpp
+++ b/examples/01_basic/main.cpp
@@ -6,18 +6,18 @@
 
 struct VerboseOption
 {
-    static constexpr std::string_view identifier{ "--verbose" };
-    static constexpr std::string_view alias{ "-v" };
-    static constexpr std::string_view description{ "Enable verbose output" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--verbose"};
+    static constexpr std::string_view alias{"-v"};
+    static constexpr std::string_view description{"Enable verbose output"};
+    static constexpr bool             required{false};
 };
 
 struct FileOption
 {
-    static constexpr std::string_view identifier{ "--file" };
-    static constexpr std::string_view value_hint{ "FILE" };
-    static constexpr std::string_view description{ "Specify file to load" };
-    static constexpr bool             required{ true };
+    static constexpr std::string_view identifier{"--file"};
+    static constexpr std::string_view value_hint{"FILE"};
+    static constexpr std::string_view description{"Specify file to load"};
+    static constexpr bool             required{true};
     using ValueType = std::filesystem::path;
 };
 

--- a/examples/hello/main.cpp
+++ b/examples/hello/main.cpp
@@ -5,9 +5,9 @@
 
 struct MyStruct
 {
-    explicit MyStruct(const float data)
-        : data(data)
-    {}
+    explicit MyStruct(const float data) : data(data)
+    {
+    }
 
     float data;
 };
@@ -26,76 +26,76 @@ CLArgs::from_string<MyStruct>(const std::string_view sv)
 
 struct MyStructOption
 {
-    static constexpr std::string_view identifier{ "--mystruct" };
-    static constexpr std::string_view alias{ "-ms" };
-    static constexpr std::string_view description{ "Specify value for my struct" };
-    static constexpr std::string_view value_hint{ "NUMBER" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--mystruct"};
+    static constexpr std::string_view alias{"-ms"};
+    static constexpr std::string_view description{"Specify value for my struct"};
+    static constexpr std::string_view value_hint{"NUMBER"};
+    static constexpr bool             required{false};
     using ValueType = MyStruct;
 };
 
 struct HelpFlag
 {
-    static constexpr std::string_view identifier{ "--help" };
-    static constexpr std::string_view alias{ "-h" };
-    static constexpr std::string_view description{ "Display help menu" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--help"};
+    static constexpr std::string_view alias{"-h"};
+    static constexpr std::string_view description{"Display help menu"};
+    static constexpr bool             required{false};
 };
 
 struct HelloFlag
 {
-    static constexpr std::string_view identifier{ "--hello" };
-    static constexpr std::string_view description{ "Print hello world" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--hello"};
+    static constexpr std::string_view description{"Print hello world"};
+    static constexpr bool             required{false};
 };
 
 struct VerboseFlag
 {
-    static constexpr std::string_view identifier{ "--verbose" };
-    static constexpr std::string_view alias{ "-v" };
-    static constexpr std::string_view description{ "Enable verbose printing" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--verbose"};
+    static constexpr std::string_view alias{"-v"};
+    static constexpr std::string_view description{"Enable verbose printing"};
+    static constexpr bool             required{false};
 };
 
 struct FileOption
 {
-    static constexpr std::string_view identifier{ "--file" };
-    static constexpr std::string_view alias{ "-f" };
-    static constexpr std::string_view description{ "Specify input file" };
-    static constexpr std::string_view value_hint{ "FILE" };
-    static constexpr bool             required{ true };
+    static constexpr std::string_view identifier{"--file"};
+    static constexpr std::string_view alias{"-f"};
+    static constexpr std::string_view description{"Specify input file"};
+    static constexpr std::string_view value_hint{"FILE"};
+    static constexpr bool             required{true};
     using ValueType = std::filesystem::path;
 };
 
 struct DirectoryOption
 {
-    static constexpr std::string_view identifier{ "--directory" };
-    static constexpr std::string_view description{ "Specify input directory" };
-    static constexpr std::string_view value_hint{ "PATH" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--directory"};
+    static constexpr std::string_view description{"Specify input directory"};
+    static constexpr std::string_view value_hint{"PATH"};
+    static constexpr bool             required{false};
     using ValueType = std::string;
 };
 
 struct FloatOption
 {
-    static constexpr std::string_view identifier{ "--float" };
-    static constexpr std::string_view description{ "Specify floating point value" };
-    static constexpr std::string_view value_hint{ "NUMBER" };
-    static constexpr bool             required{ true };
+    static constexpr std::string_view identifier{"--float"};
+    static constexpr std::string_view description{"Specify floating point value"};
+    static constexpr std::string_view value_hint{"NUMBER"};
+    static constexpr bool             required{true};
     using ValueType = float;
 };
 
 struct CharOption
 {
-    static constexpr std::string_view identifier{ "--char" };
-    static constexpr std::string_view description{ "Specify character value" };
-    static constexpr std::string_view value_hint{ "CHARACTER" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--char"};
+    static constexpr std::string_view description{"Specify character value"};
+    static constexpr std::string_view value_hint{"CHARACTER"};
+    static constexpr bool             required{false};
     using ValueType = char;
 };
 
-using ArgumentParser = CLArgs::Parser<HelpFlag, HelloFlag, VerboseFlag, MyStructOption, FileOption, DirectoryOption,
-                                      FloatOption, CharOption>;
+using ArgumentParser =
+        CLArgs::Parser<HelpFlag, HelloFlag, VerboseFlag, MyStructOption, FileOption, DirectoryOption, FloatOption, CharOption>;
 
 int
 main(const int argc, char **argv)

--- a/include/CLArgs/concepts.hpp
+++ b/include/CLArgs/concepts.hpp
@@ -7,34 +7,21 @@
 namespace CLArgs
 {
     template <typename T>
-    concept CmdOption = requires
-    {
-        {
-            T::identifier
-        } -> std::convertible_to<std::string_view>;
-        {
-            T::description
-        } -> std::convertible_to<std::string_view>;
-        {
-            T::required
-        } -> std::convertible_to<bool>;
+    concept CmdOption = requires {
+        { T::identifier } -> std::convertible_to<std::string_view>;
+        { T::description } -> std::convertible_to<std::string_view>;
+        { T::required } -> std::convertible_to<bool>;
     };
 
     template <typename T>
-    concept CmdHasValue = requires
-    {
-        {
-            T::value_hint
-        } -> std::convertible_to<std::string_view>;
+    concept CmdHasValue = requires {
+        { T::value_hint } -> std::convertible_to<std::string_view>;
         typename T::ValueType;
     };
 
     template <typename T>
-    concept CmdHasAlias = requires
-    {
-        {
-            T::alias
-        } -> std::convertible_to<std::string_view>;
+    concept CmdHasAlias = requires {
+        { T::alias } -> std::convertible_to<std::string_view>;
     };
 
     template <typename T, typename... Ts>

--- a/include/CLArgs/from_string.hpp
+++ b/include/CLArgs/from_string.hpp
@@ -170,8 +170,7 @@ CLArgs::from_string<bool>(const std::string_view sv)
         return false;
     }
 
-    throw std::invalid_argument(
-        R"(Valid bool values are "true", "True", "TRUE", "1", "false", "False", "FALSE" and "0")");
+    throw std::invalid_argument(R"(Valid bool values are "true", "True", "TRUE", "1", "false", "False", "FALSE" and "0")");
 }
 
 template <>

--- a/include/CLArgs/macro_api.hpp
+++ b/include/CLArgs/macro_api.hpp
@@ -3,34 +3,34 @@
 
 #include <string_view>
 
-#define CLARGS_IDENTIFIER(str)                   \
-    static constexpr std::string_view identifier \
-    {                                            \
-        str                                      \
+#define CLARGS_IDENTIFIER(str)                                                                                                             \
+    static constexpr std::string_view identifier                                                                                           \
+    {                                                                                                                                      \
+        str                                                                                                                                \
     }
 
-#define CLARGS_ALIAS(str)                   \
-    static constexpr std::string_view alias \
-    {                                       \
-        str                                 \
+#define CLARGS_ALIAS(str)                                                                                                                  \
+    static constexpr std::string_view alias                                                                                                \
+    {                                                                                                                                      \
+        str                                                                                                                                \
     }
 
-#define CLARGS_DESCRIPTION(str)                   \
-    static constexpr std::string_view description \
-    {                                             \
-        str                                       \
+#define CLARGS_DESCRIPTION(str)                                                                                                            \
+    static constexpr std::string_view description                                                                                          \
+    {                                                                                                                                      \
+        str                                                                                                                                \
     }
 
-#define CLARGS_REQUIRED(reqd)      \
-    static constexpr bool required \
-    {                              \
-        reqd                       \
+#define CLARGS_REQUIRED(reqd)                                                                                                              \
+    static constexpr bool required                                                                                                         \
+    {                                                                                                                                      \
+        reqd                                                                                                                               \
     }
 
-#define CLARGS_VALUE_HINT(str)                   \
-    static constexpr std::string_view value_hint \
-    {                                            \
-        str                                      \
+#define CLARGS_VALUE_HINT(str)                                                                                                             \
+    static constexpr std::string_view value_hint                                                                                           \
+    {                                                                                                                                      \
+        str                                                                                                                                \
     }
 
 #define CLARGS_VALUE_TYPE(type) using ValueType = type

--- a/include/CLArgs/misc.hpp
+++ b/include/CLArgs/misc.hpp
@@ -9,11 +9,11 @@
 #include <string_view>
 
 #ifndef NDEBUG
-#    define CLARGS_ASSERT(expr, msg) ::CLArgs::_internal::assert_impl(expr, msg, __FILE__, __LINE__)
-#    define CLARGS_DEBUG_BREAK()     CLARGS_PLATFORM_DEBUG_BREAK()
+    #define CLARGS_ASSERT(expr, msg) ::CLArgs::_internal::assert_impl(expr, msg, __FILE__, __LINE__)
+    #define CLARGS_DEBUG_BREAK() CLARGS_PLATFORM_DEBUG_BREAK()
 #else
-#    define CLARGS_ASSERT(expr, msg)
-#    define CLARGS_DEBUG_BREAK()
+    #define CLARGS_ASSERT(expr, msg)
+    #define CLARGS_DEBUG_BREAK()
 #endif
 
 namespace CLArgs::_internal

--- a/include/CLArgs/parser.hpp
+++ b/include/CLArgs/parser.hpp
@@ -1,13 +1,6 @@
 #ifndef CLARGS_PARSER_HPP
 #define CLARGS_PARSER_HPP
 
-/**
- * TODO:
- * - Handle option groups with validators (For example mutually exclusive options)
- * - Proper from_string() implementation. We currently just use std::stringstream as a middleman for casting, but it is
- * expensive
- */
-
 #include <CLArgs/concepts.hpp>
 #include <CLArgs/from_string.hpp>
 #include <CLArgs/misc.hpp>

--- a/include/CLArgs/parser.hpp
+++ b/include/CLArgs/parser.hpp
@@ -35,7 +35,7 @@ namespace CLArgs
     template <CmdOption... Options>
     class Parser
     {
-      public:
+    public:
         Parser() noexcept = default;
 
         Parser(const Parser &)  = delete;
@@ -51,13 +51,14 @@ namespace CLArgs
         [[nodiscard]] std::filesystem::path program() const noexcept;
 
         template <CmdOption Option>
-        [[nodiscard]] bool has_option() const noexcept requires IsPartOf<Option, Options...>;
+        [[nodiscard]] bool has_option() const noexcept
+            requires IsPartOf<Option, Options...>;
 
         template <CmdOption Option>
-        [[nodiscard]] std::optional<typename Option::ValueType>
-        get_option_value() const noexcept requires IsPartOf<Option, Options...> &&CmdHasValue<Option>;
+        [[nodiscard]] std::optional<typename Option::ValueType> get_option_value() const noexcept
+            requires IsPartOf<Option, Options...> && CmdHasValue<Option>;
 
-      private:
+    private:
         void check_invariant() const;
 
         template <CmdOption Option, CmdOption... Rest>
@@ -75,9 +76,9 @@ namespace CLArgs
         std::string_view                              program_;
         std::unordered_map<std::type_index, std::any> options_;
 
-        bool has_successfully_parsed_args_{ false };
+        bool has_successfully_parsed_args_{false};
 
-        static constexpr std::size_t max_identifier_length_{ max_identifier_length<Options...>() };
+        static constexpr std::size_t max_identifier_length_{max_identifier_length<Options...>()};
     };
 } // namespace CLArgs
 
@@ -113,12 +114,11 @@ CLArgs::Parser<Options...>::parse(int argc, char **argv)
 template <CLArgs::CmdOption... Options>
 template <CLArgs::CmdOption Option, CLArgs::CmdOption... Rest>
 void
-CLArgs::Parser<Options...>::process_arg(std::vector<std::string_view>           &all,
-                                        std::vector<std::string_view>::iterator &current)
+CLArgs::Parser<Options...>::process_arg(std::vector<std::string_view> &all, std::vector<std::string_view>::iterator &current)
 {
     std::string_view arg = *current;
 
-    bool found{ false };
+    bool found{false};
     if (arg == Option::identifier)
     {
         found = true;
@@ -164,8 +164,8 @@ CLArgs::Parser<Options...>::process_arg(std::vector<std::string_view>           
             catch (std::exception &e)
             {
                 std::stringstream ss;
-                ss << "Failed to parse \"" << *value_iter << "\" as type " << typeid(typename Option::ValueType).name()
-                   << " for option \"" << arg << "\": " << e.what();
+                ss << "Failed to parse \"" << *value_iter << "\" as type " << typeid(typename Option::ValueType).name() << " for option \""
+                   << arg << "\": " << e.what();
                 throw std::invalid_argument(ss.str());
             }
             all.erase(current, value_iter + 1);
@@ -238,7 +238,8 @@ CLArgs::Parser<Options...>::program() const noexcept
 template <CLArgs::CmdOption... Options>
 template <CLArgs::CmdOption Option>
 bool
-CLArgs::Parser<Options...>::has_option() const noexcept requires IsPartOf<Option, Options...>
+CLArgs::Parser<Options...>::has_option() const noexcept
+    requires IsPartOf<Option, Options...>
 {
     check_invariant();
     return options_.contains(std::type_index(typeid(Option)));
@@ -247,8 +248,8 @@ CLArgs::Parser<Options...>::has_option() const noexcept requires IsPartOf<Option
 template <CLArgs::CmdOption... Options>
 template <CLArgs::CmdOption Option>
 std::optional<typename Option::ValueType>
-CLArgs::Parser<Options...>::get_option_value()
-    const noexcept requires IsPartOf<Option, Options...> &&CmdHasValue<Option>
+CLArgs::Parser<Options...>::get_option_value() const noexcept
+    requires IsPartOf<Option, Options...> && CmdHasValue<Option>
 {
     check_invariant();
 

--- a/include/CLArgs/platform.hpp
+++ b/include/CLArgs/platform.hpp
@@ -2,16 +2,16 @@
 #define CLARGS_PLATFORM_HPP
 
 #if defined(_WIN32)
-#    ifndef NOMINMAX
-#        define NOMINMAX
-#    endif
-#    include <windows.h>
-#    define CLARGS_PLATFORM_DEBUG_BREAK() DebugBreak();
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
+    #include <windows.h>
+    #define CLARGS_PLATFORM_DEBUG_BREAK() DebugBreak();
 #elif defined(__linux__)
-#    include <csignal>
-#    define CLARGS_PLATFORM_DEBUG_BREAK() raise(SIGTRAP);
+    #include <csignal>
+    #define CLARGS_PLATFORM_DEBUG_BREAK() raise(SIGTRAP);
 #else
-#    define CLARGS_PLATFORM_DEBUG_BREAK()
+    #define CLARGS_PLATFORM_DEBUG_BREAK()
 #endif
 
 #endif

--- a/include/CLArgs/singleton.hpp
+++ b/include/CLArgs/singleton.hpp
@@ -10,7 +10,7 @@ namespace CLArgs
     {
         using ArgumentParser = Parser<Options...>;
 
-      public:
+    public:
         static void parse(int, char **);
 
         static std::string help() noexcept;
@@ -18,13 +18,14 @@ namespace CLArgs
         static std::filesystem::path program() noexcept;
 
         template <CmdOption Option>
-        static bool has_option() noexcept requires CLArgs::IsPartOf<Option, Options...>;
+        static bool has_option() noexcept
+            requires CLArgs::IsPartOf<Option, Options...>;
 
         template <CmdOption Option>
-        std::optional<typename Option::ValueType> static get_option_value() noexcept requires
-            CLArgs::IsPartOf<Option, Options...> &&CLArgs::CmdHasValue<Option>;
+        std::optional<typename Option::ValueType> static get_option_value() noexcept
+            requires CLArgs::IsPartOf<Option, Options...> && CLArgs::CmdHasValue<Option>;
 
-      private:
+    private:
         ParserSingleton() = default;
 
         static ArgumentParser &
@@ -60,7 +61,8 @@ CLArgs::ParserSingleton<Options...>::program() noexcept
 template <CLArgs::CmdOption... Options>
 template <CLArgs::CmdOption Option>
 bool
-CLArgs::ParserSingleton<Options...>::has_option() noexcept requires CLArgs::IsPartOf<Option, Options...>
+CLArgs::ParserSingleton<Options...>::has_option() noexcept
+    requires CLArgs::IsPartOf<Option, Options...>
 {
     return get_instance().template has_option<Option>();
 }
@@ -68,8 +70,8 @@ CLArgs::ParserSingleton<Options...>::has_option() noexcept requires CLArgs::IsPa
 template <CLArgs::CmdOption... Options>
 template <CLArgs::CmdOption Option>
 std::optional<typename Option::ValueType>
-CLArgs::ParserSingleton<Options...>::get_option_value() noexcept requires
-    CLArgs::IsPartOf<Option, Options...> &&CLArgs::CmdHasValue<Option>
+CLArgs::ParserSingleton<Options...>::get_option_value() noexcept
+    requires CLArgs::IsPartOf<Option, Options...> && CLArgs::CmdHasValue<Option>
 {
     return get_instance().template get_option_value<Option>();
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -9,7 +9,7 @@ std::pair<int, char **>
 create_argc_argv(const std::array<const char *, N> &args)
 {
     const int argc = static_cast<int>(N);
-    char    **argv = const_cast<char **>(args.data()); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    char    **argv = const_cast<char **>(args.data());
     return std::make_pair(argc, argv);
 }
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -5,34 +5,35 @@
 #include <array>
 
 template <std::size_t N>
-std::pair<int, char **> create_argc_argv(const std::array<const char *, N>& args)
+std::pair<int, char **>
+create_argc_argv(const std::array<const char *, N> &args)
 {
     const int argc = static_cast<int>(N);
-    char **argv = const_cast<char **>(args.data()); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+    char    **argv = const_cast<char **>(args.data()); // NOLINT(cppcoreguidelines-pro-type-const-cast)
     return std::make_pair(argc, argv);
 }
 
 struct VerboseOption
 {
-    static constexpr std::string_view identifier{ "--verbose" };
-    static constexpr std::string_view alias{ "-v" };
-    static constexpr std::string_view description{ "Enable verbose output" };
-    static constexpr bool             required{ false };
+    static constexpr std::string_view identifier{"--verbose"};
+    static constexpr std::string_view alias{"-v"};
+    static constexpr std::string_view description{"Enable verbose output"};
+    static constexpr bool             required{false};
 };
 
 struct FileOption
 {
-    static constexpr std::string_view identifier{ "--file" };
-    static constexpr std::string_view value_hint{ "FILE" };
-    static constexpr std::string_view description{ "Specify file to load" };
-    static constexpr bool             required{ true };
+    static constexpr std::string_view identifier{"--file"};
+    static constexpr std::string_view value_hint{"FILE"};
+    static constexpr std::string_view description{"Specify file to load"};
+    static constexpr bool             required{true};
     using ValueType = std::filesystem::path;
 };
 
 TEST_CASE("Parse arguments", "[parse]")
 {
-    constexpr std::array args = { "program", "-v", "--file", "test.txt" };
-    auto [argc, argv] = create_argc_argv(args);
+    constexpr std::array args = {"program", "-v", "--file", "test.txt"};
+    auto [argc, argv]         = create_argc_argv(args);
 
     CLArgs::Parser<VerboseOption, FileOption> parser;
     REQUIRE_NOTHROW(parser.parse(argc, argv));


### PR DESCRIPTION
Updated `.clang-format` configuration file to align more with my personal preferences.

Updated `.clang-tidy` configuration file with many check enabled. The checks are based on what I feel are useful things for a static code analysis tool to look out for. It is very focused on modernization, readability and C++ Core Guidelines.

For now clang-tidy does produce some warnings for the project. This will be resolved in a future pull request.

Closes #6.