### PR TITLE
Updated CMakeLists.txt files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,4 +19,4 @@ jobs:
     - name: make
       run: cmake --build build --target tests -j${{ runner.cpu }}
     - name: run tests
-      run: ./build/tests/tests
+      run: ./build/bin/tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,7 @@ target_include_directories(CLArgs INTERFACE
 option(CLARGS_BUILD_EXAMPLES "Build CLArgs examples" ON)
 
 if (${CLARGS_BUILD_EXAMPLES})
-    add_subdirectory(examples/01_basic)
-    add_subdirectory(examples/02_singleton)
+    add_subdirectory(examples)
 endif ()
 
 option(CLARGS_BUILD_TESTS "Build CLArgs tests" ON)

--- a/examples/01_basic/CMakeLists.txt
+++ b/examples/01_basic/CMakeLists.txt
@@ -1,18 +1,3 @@
-cmake_minimum_required(VERSION 3.20)
-
-if (WIN32)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-endif ()
-
-project(Basic)
-
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/run_tree>")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
-
 add_executable(Basic
         main.cpp
 )

--- a/examples/02_singleton/CMakeLists.txt
+++ b/examples/02_singleton/CMakeLists.txt
@@ -1,18 +1,3 @@
-cmake_minimum_required(VERSION 3.20)
-
-if (WIN32)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-endif ()
-
-project(Singleton)
-
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/run_tree>")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
-
 add_executable(Singleton
         main.cpp
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,15 @@
+if (WIN32)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif ()
+
+project(ClargsExamples)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/bin>")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
+
+add_subdirectory(01_basic)
+add_subdirectory(02_singleton)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,10 @@ if (WIN32)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif ()
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/bin>")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "$<1:${CMAKE_BINARY_DIR}/lib>")
+
 Include(FetchContent)
 
 FetchContent_Declare(


### PR DESCRIPTION
Added a CMakeLists.txt file in the examples directory which collects all example executables. Reduces the size of the root CMakeLists.txt file, and we can now collect common configuration for the example executables in one file, instead of copying them across them all.